### PR TITLE
Fix typos and misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Building native-like Elixir apps for Windows, MacOS, Linux, iOS and Android usin
 ## Changes in 1.3
 
 - Added `Env.subscribe/1` to listen to MacOS application events such as `{:open_url, url}` when a url associated with the application is clicked.
-- Using (experimantal) dbus support to render the systray icon on linux
+- Using (experimental) dbus support to render the systray icon on linux
 - Added `Menu.escape_attribute/1`
 - Added `Window.url/1`
 - Added `Window.hide/1` and `Window.is_hidden/`

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,3 @@
 import Config
+
+config :phoenix, :json_library, Jason

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -76,7 +76,7 @@ nvm install v12.16.1
 
 **Using custom WxWidgets**
 
-On macOS good wxWidgets support is pretty recent. You might want to try a newer e.g. master version when you spot visual issues in the native Menues or Taskbar Icon behaviour:
+On macOS good wxWidgets support is pretty recent. You might want to try a newer e.g. master version when you spot visual issues in the native Menus or Taskbar Icon behaviour:
 
 ```bash
 mkdir ~/projects && cd ~/projects

--- a/lib/desktop/env.ex
+++ b/lib/desktop/env.ex
@@ -2,7 +2,7 @@ defmodule Desktop.Env do
   @moduledoc """
     Env holds any needed :wx / Desktop application state. Currently
     it keeps track of
-      * The open Dekstop.Window(s),
+      * The open Desktop.Window(s),
       * OS Application events (such as when a file is dragged on the application icon)
       * The :wx environment
       * The dbus connection (sni) on linux

--- a/lib/desktop/menu.ex
+++ b/lib/desktop/menu.ex
@@ -2,7 +2,7 @@ defmodule Desktop.Menu do
   @moduledoc """
   Menu module used to create and handle menus in Desktop
 
-  Menues are defined similiar to Live View using a callback module an XML:
+  Menus are defined similar to Live View using a callback module an XML:
 
   ```
     defmodule ExampleMenuBar do
@@ -53,13 +53,13 @@ defmodule Desktop.Menu do
   # Template
 
   As in live view the template can either be embedded in the `def render(assigns)`
-  method or it can be side loaded as a .eex file next to the menues .ex file.
+  method or it can be side loaded as a .eex file next to the menus .ex file.
 
   # XML Structure
 
   These items are defined:
 
-  ## `<menubar>...menues...</menubar>`
+  ## `<menubar>...menus...</menubar>`
 
   For an application (window) menubar this must be the root element. When
   passing a menubar to `Desktop.Window` start parameters this has to be the root element.

--- a/lib/desktop/menu/adapters/wx.ex
+++ b/lib/desktop/menu/adapters/wx.ex
@@ -215,33 +215,33 @@ defmodule Desktop.Menu.Adapter.Wx do
     :wx.set_env(Desktop.Env.wx_env())
 
     :wx.batch(fn ->
-      menues = create_menu_items(nil, dom)
+      menus = create_menu_items(nil, dom)
 
-      # Enum.each(menues, fn {menu, _label} ->
+      # Enum.each(menus, fn {menu, _label} ->
       #   :wxMenu.connect(
       #     menu,
       #     :menu_close
       #   )
       # end)
 
-      update_menubar(menubar, menues)
+      update_menubar(menubar, menus)
     end)
 
     adapter
   end
 
-  defp update_menubar(adapter = %__MODULE__{menubar: menubar}, menues) do
+  defp update_menubar(adapter = %__MODULE__{menubar: menubar}, menus) do
     :wx.batch(fn ->
-      update_menubar(menubar, menues)
+      update_menubar(menubar, menus)
     end)
 
     adapter
   end
 
-  defp update_menubar(menubar, menues) do
+  defp update_menubar(menubar, menus) do
     menubar
     |> do_reset_menubar()
-    |> do_update_menubar(menues)
+    |> do_update_menubar(menus)
   end
 
   defp do_reset_menubar(menubar) do
@@ -262,9 +262,9 @@ defmodule Desktop.Menu.Adapter.Wx do
     menubar
   end
 
-  defp do_update_menubar(menubar, [{menu, label} | menues]) do
+  defp do_update_menubar(menubar, [{menu, label} | menus]) do
     :wxMenuBar.append(menubar, menu, label)
-    do_update_menubar(menubar, menues)
+    do_update_menubar(menubar, menus)
   end
 
   defp create_menu_items(_evt_handler, []) do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,5 +1,4 @@
 defmodule Desktop.ParserTest do
   use ExUnit.Case
-  alias Desktop.Menu.Parser
   doctest Desktop
 end


### PR DESCRIPTION
List of changes:
- resolves typos found via `codespell -S deps -L froms,ndoes`
- remove warning by setting JSON library explicitly
- remove unused alias