### PR TITLE
Updating version of desktop on guide

### DIFF
--- a/guides/your_first_app.md
+++ b/guides/your_first_app.md
@@ -9,7 +9,7 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
     ```elixir
     def deps do
     [
-        {:desktop, "~> 1.4"}
+        {:desktop, "~> 1.5"}
     ]
     end
     ```


### PR DESCRIPTION
See: https://github.com/elixir-desktop/desktop/issues/39


The guide uses an old version of Desktop which will break with the newest version of LiveView (1.18).
Since guides are usually the first resources people see, we should update it.