### PR TITLE
Update getting started guide

### DIFF
--- a/guides/your_first_app.md
+++ b/guides/your_first_app.md
@@ -20,13 +20,13 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
     children = [
         # After your other children
         # Starting Desktop.Windows
-		{Desktop.Window,
+        {Desktop.Window,
          [
             app: :your_app,
             id: YourAppWindow,
             url: &YourAppWeb.Endpoint.url/0
          ]}
-	]
+    ]
     Supervisor.start_link()
     ```
 

--- a/guides/your_first_app.md
+++ b/guides/your_first_app.md
@@ -17,20 +17,22 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
 1. Add a Desktop.Window child to your supervision tree on startup. E.g. in `application.ex`
 
     ```elixir
-    children = [{
+    children = [
         # After your other children
         # Starting Desktop.Windows
-        Desktop.Window,
-        [
+		{Desktop.Window,
+         [
             app: :your_app,
             id: YourAppWindow,
             url: &YourAppWeb.Endpoint.url/0
-        ]
-    }]
+         ]}
+	]
     Supervisor.start_link()
     ```
 
-1. In `endpoint.ex` call `use Desktop.Endpoint` instead of `use Phoenix.Endpoint`
+	Note: you still need to start your phoenix Endpoint, add `Desktop.Window` in _addition_ to your `Desktop.Window`
+
+1. In `endpoint.ex` call `use Desktop.Endpoint` **instead of** `use Phoenix.Endpoint`
 
     ```elixir
     defmodule YourAppWeb.Endpoint do
@@ -38,10 +40,10 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
       ...
     end
     ```
-    
+
     1. Consider authenticating requests
 
-    Using the `Desktop.Auth` plug makes sure only request from the app's webview are allowed.
+    Adding the `Desktop.Auth` plug to your endpoint ensures that only request from the app's webview are allowed.
 
     ```elixir
     defmodule YourAppWeb.Endpoint do
@@ -65,7 +67,7 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
 
 
     ```elixir
-      def start(_type, args) do 
+      def start(_type, args) do
         Desktop.identify_default_locale(YourWebApp.Gettext)
 
         children = [
@@ -76,3 +78,6 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
       end
     ```
 
+1. Run your application with `mix phx.server`
+
+  The desktop application window should now be visible!

--- a/guides/your_first_app.md
+++ b/guides/your_first_app.md
@@ -53,7 +53,7 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
     end
     ```
 
-1. In `config.exs` ensure http is configured and the port is set to `0` so it's chosen automatically
+1. In your application configuration (by default in `config/dev.exs` and `config/runtime.exs)` ensure http is configured and the port is set to `0` so it's chosen automatically, as well as setting `server: true` so that your Phoenix Endpoint starts automatically (without having to explicitly call `mix phx.server`):
 
     ```elixir
     # Configures the endpoint
@@ -78,6 +78,6 @@ To convert a barebones Phoenix Live View example to a Desktop Application you wi
       end
     ```
 
-1. Run your application with `mix phx.server`
+1. Run your application with `mix run`
 
   The desktop application window should now be visible!


### PR DESCRIPTION
Changes include:
- Whitespace fixes
- Move the curly brackets for the tuple closer
  - I didn't see the curly brackets initially
- Make it extra clear that we should `use Desktop.Endpoint` instead of `use Phoenix.Endpoint`
- Various wording changes
- Give some guidance about how to run your application at the end of setup and make it clear that `phx.server` should still be needed

Note: if you don't run `phx.server` (or set your endpoint configuration to `server: true`) you will get an error like:
```
[error] ** wx object server {:local, HappyHelperWindow} terminating
** Last message in was {:"$gen_cast", {:show, &HappyHelperWeb.Endpoint.url/0}}
** When Server state == %Desktop.Window{
  module: nil,
  taskbar: nil,
  frame: {:wx_ref, 35, :wxFrame, []},
  notifications: %{},
  webview: {:wx_ref, 53, :wxWebView, []},
  home_url: &HappyHelperWeb.Endpoint.url/0,
  last_url: nil,
  title: "Elixir.HappyHelperWindow",
  rebuild: 0,
  rebuild_timer: nil
}
** Reason for termination ==
** {:badarg,
 [
   {:erlang, :binary_to_existing_atom,
    ["Elixir.HappyHelperWeb.Endpoint.HTTP", :utf8],
    [error_info: %{module: :erl_erts_errors}]},
   {:elixir_aliases, :safe_concat, 1,
    [file: ~c"src/elixir_aliases.erl", line: 139]},
   {HappyHelperWeb.Endpoint, :url, 0,
    [file: ~c"lib/happy_helper_web/endpoint.ex", line: 3]},
   {Desktop.Window, :prepare_url, 1,
    [file: ~c"lib/desktop/window.ex", line: 668]},
   {Desktop.Window, :handle_cast, 2,
    [file: ~c"lib/desktop/window.ex", line: 606]},
   {:wx_object, :handle_msg, 5, [file: ~c"wx_object.erl", line: 493]},
   {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}
 ]}
```

Which isn't that easy to track down (probably took me ~30m of semi-distracted time)