### PR TITLE
Integrate with new server_info callback on endpoints

### DIFF
--- a/lib/desktop/endpoint.ex
+++ b/lib/desktop/endpoint.ex
@@ -13,7 +13,7 @@ defmodule Desktop.Endpoint do
 
         case Keyword.get(config(scheme), :port, 0) do
           0 -> String.replace(url, ":0", ":#{get_dynamic_port(scheme)}")
-          port -> url
+          _port -> url
         end
       end
 

--- a/lib/desktop/endpoint.ex
+++ b/lib/desktop/endpoint.ex
@@ -1,14 +1,33 @@
 defmodule Desktop.Endpoint do
   @doc false
   defmacro __using__(opts) do
+    scheme = Keyword.get(opts, :desktop_scheme, :http)
+
     quote do
       use Phoenix.Endpoint, unquote(opts)
       defoverridable url: 0
 
       def url do
         url = super()
-        endpoint = Module.safe_concat(__MODULE__, HTTP)
-        String.replace(url, ":0", ":#{:ranch.get_port(endpoint)}")
+        scheme = unquote(scheme)
+
+        case Keyword.get(config(scheme), :port, 0) do
+          0 -> String.replace(url, ":0", ":#{get_dynamic_port(scheme)}")
+          port -> url
+        end
+      end
+
+      if Version.match?(:phoenix |> Application.spec(:vsn) |> List.to_string(), "~> 1.7.10") do
+        def get_dynamic_port(scheme) do
+          {:ok, {_ip, port}} = server_info(scheme)
+          port
+        end
+      else
+        # Supports only cowboy adapter for phoenix
+        def get_dynamic_port(scheme) do
+          ref = Module.safe_concat(__MODULE__, scheme |> Atom.to_string() |> String.upcase())
+          :ranch.get_port(ref)
+        end
       end
     end
   end

--- a/lib/desktop/endpoint.ex
+++ b/lib/desktop/endpoint.ex
@@ -1,7 +1,7 @@
 defmodule Desktop.Endpoint do
   @doc false
   defmacro __using__(opts) do
-    scheme = Keyword.get(opts, :desktop_scheme, :http)
+    {scheme, opts} = Keyword.pop(opts, :desktop_scheme, :http)
 
     quote do
       use Phoenix.Endpoint, unquote(opts)


### PR DESCRIPTION
This makes `Desktop.Endpoint` not depend on any implementation details / any specific adapter with phoenix version `~> 1.7.10`