### PR TITLE
Crude changes to support liveview 1.x

### DIFF
--- a/lib/desktop/endpoint.ex
+++ b/lib/desktop/endpoint.ex
@@ -17,17 +17,9 @@ defmodule Desktop.Endpoint do
         end
       end
 
-      if Version.match?(:phoenix |> Application.spec(:vsn) |> List.to_string(), "~> 1.7.10") do
-        def get_dynamic_port(scheme) do
-          {:ok, {_ip, port}} = server_info(scheme)
-          port
-        end
-      else
-        # Supports only cowboy adapter for phoenix
-        def get_dynamic_port(scheme) do
-          ref = Module.safe_concat(__MODULE__, scheme |> Atom.to_string() |> String.upcase())
-          :ranch.get_port(ref)
-        end
+      def get_dynamic_port(scheme) do
+        {:ok, {_ip, port}} = server_info(scheme)
+        port
       end
     end
   end

--- a/lib/desktop/menu.ex
+++ b/lib/desktop/menu.ex
@@ -28,21 +28,21 @@ defmodule Desktop.Menu do
 
       @impl true
       def render(assigns) do
-        ~E\"""
+        ~H\"""
         <menubar>
-          <menu label="<%= gettext "File" %>">
-              <item onclick="open"><%= gettext "Open" %></item>
+          <menu label={gettext "File"}>
+              <item onclick="open">{gettext "Open"}</item>
               <hr/>
-              <item onclick="quit"><%= gettext "Quit" %></item>
+              <item onclick="quit">{gettext "Quit"}</item>
           </menu>
-          <menu label="<%= gettext "Items" %>">
+          <menu label={gettext "Items"}>
             <%= for item <- @items do %>
-              <item><%= item.name %></item>
+              <item>{item.name}</item>
             <% end %>
           </menu>
-          <menu label="<%= gettext "Help" %>">
-              <item onclick="help"><%= gettext "Show Documentation" %></item>
-              <item onclick="about"><%= gettext "About" %></item>
+          <menu label={gettext "Help"}>
+              <item onclick="help">{gettext "Show Documentation"}</item>
+              <item onclick="about">{gettext "About"}</item>
           </menu>
         </menubar>
         \"""
@@ -143,7 +143,6 @@ defmodule Desktop.Menu do
       quote do
         @behaviour Desktop.Menu
         import Desktop.Menu, only: [assign: 2, assign: 3, assign_new: 3, connected?: 1]
-        import Phoenix.HTML, only: [sigil_e: 2, sigil_E: 2]
         import Phoenix.LiveView.Helpers, only: [sigil_L: 2, sigil_H: 2]
         alias Desktop.Menu
 
@@ -153,7 +152,6 @@ defmodule Desktop.Menu do
       quote do
         @behaviour Desktop.Menu
         import Desktop.Menu, only: [assign: 2, assign: 3, assign_new: 3, connected?: 1]
-        import Phoenix.HTML, only: [sigil_e: 2, sigil_E: 2]
         import Phoenix.LiveView.Helpers, only: [sigil_L: 2]
         import Phoenix.Component, only: [sigil_H: 2]
         alias Desktop.Menu

--- a/lib/desktop/wx.ex
+++ b/lib/desktop/wx.ex
@@ -1,3 +1,4 @@
+# TODO: less stringy metaprogramming
 defmodule Desktop.Wx do
   @moduledoc """
   Elixir version of the constants found in the wx.hrl file, reduced to what is needed in this sample only.
@@ -25,11 +26,12 @@ defmodule Desktop.Wx do
   )
 
   for wx_constant <- @constants do
-    Module.eval_quoted(
-      __MODULE__,
+    Code.eval_quoted(
       Code.string_to_quoted("""
         def wx#{wx_constant}, do: :desktop_wx.get(:wx#{wx_constant})
-      """)
+      """),
+      [],
+      module: __MODULE__
     )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -83,8 +83,8 @@ defmodule Desktop.MixProject do
       # {:ex_sni, path: "../ex_sni"},
 
       # Phoenix & Plug
-      {:phoenix, "> 1.0.0"},
-      {:phoenix_live_view, "> 0.15.0"},
+      {:phoenix, "> 1.7.10"},
+      {:phoenix_live_view, "> 1.0.0"},
       {:plug, "> 1.0.0"},
       {:gettext, "> 0.10.0"}
     ]


### PR DESCRIPTION
Requires phoenix 1.7.10 and liveview 1.x.
- sigil_e is deprecated
- Module.eval_quoted is deprecated

Seems to work!