### PR TITLE
added on-close option for multiple windows in desktop app

### DIFF
--- a/docs/sdl-on-close-option.md
+++ b/docs/sdl-on-close-option.md
@@ -1,0 +1,208 @@
+# SDL: Add `on_close` Option to `Desktop.Window`
+
+**Author:** Robert French
+**Date:** 2026-02-23
+**Status:** Proposed
+**Affects:** `Desktop.Window`
+
+---
+
+## Problem
+
+Applications that use multiple `Desktop.Window` instances have no way to control
+what happens when a user clicks the native close button (the red X on macOS, the
+X on Windows/Linux) on a secondary window.
+
+The current `handle_cast(:close_window, ...)` implementation decides the close
+behavior based on the presence of a `taskbar` (which is derived from the
+`icon_menu` option):
+
+```elixir
+if taskbar == nil do
+  OS.shutdown()    # terminates the entire application
+else
+  :wxFrame.hide(frame)
+end
+```
+
+This means the **only** way to get hide-on-close behavior is to provide an
+`icon_menu`, which creates a system tray icon. For secondary windows like
+Settings or Preferences panels, this is inappropriate — they should be
+dismissible without either terminating the application or requiring a taskbar
+icon.
+
+### Impact
+
+On macOS, `OS.shutdown()` during wxWidgets teardown of a secondary window causes
+a segmentation fault (SIGSEGV, exit code 139). On other platforms it causes an
+unexpected full application exit when the user only intended to close a secondary
+window.
+
+---
+
+## Solution
+
+Add an explicit `on_close` configuration option to `Desktop.Window` that
+decouples the close behavior from the taskbar presence.
+
+### New Option
+
+| Option | Values | Default | Description |
+|---|---|---|---|
+| `:on_close` | `:quit`, `:hide` | `:quit` | Controls behavior when the native close button is clicked |
+
+- **`:quit`** — Existing behavior. Shuts down the application (via
+  `OS.shutdown()`). Appropriate for primary/main windows.
+- **`:hide`** — Hides the window frame. Appropriate for secondary windows
+  (settings, preferences, tool panels) that should be dismissible without
+  terminating the application.
+
+### Usage
+
+```elixir
+children = [
+  # Primary window — closes the app (default behavior, unchanged)
+  {Desktop.Window,
+   [
+     app: :my_app,
+     id: MainWindow,
+     title: "My App",
+     icon_menu: MyApp.IconMenu,
+     url: &MyAppWeb.Endpoint.url/0
+   ]},
+
+  # Secondary window — hides on close
+  {Desktop.Window,
+   [
+     app: :my_app,
+     id: SettingsWindow,
+     title: "Settings",
+     hidden: true,
+     on_close: :hide,
+     url: fn -> MyAppWeb.Endpoint.url() <> "/settings" end
+   ]}
+]
+```
+
+---
+
+## Changes
+
+### 1. `%Desktop.Window{}` struct (`lib/desktop/window.ex`)
+
+Add `on_close` field with a default of `:quit` for full backwards compatibility:
+
+```elixir
+defstruct [
+  :module,
+  :taskbar,
+  :frame,
+  :notifications,
+  :webview,
+  :home_url,
+  :last_url,
+  :title,
+  on_close: :quit
+]
+```
+
+### 2. `init/1` (`lib/desktop/window.ex`)
+
+Read the option from the configuration keywords and store it in the struct:
+
+```elixir
+on_close = options[:on_close] || :quit
+
+ui = %Window{
+  frame: frame,
+  webview: Fallback.webview_new(frame),
+  notifications: %{},
+  home_url: url,
+  title: window_title,
+  taskbar: taskbar,
+  on_close: on_close
+}
+```
+
+### 3. `handle_cast(:close_window, ...)` (`lib/desktop/window.ex`)
+
+Check `on_close` before falling through to the existing logic:
+
+```elixir
+def handle_cast(:close_window, ui = %Window{frame: frame, taskbar: taskbar, on_close: on_close}) do
+  if on_close == :hide do
+    :wxFrame.hide(frame)
+    {:noreply, ui}
+  else
+    # Existing behavior preserved exactly as-is
+    if not :wxFrame.isShown(frame) do
+      OS.shutdown()
+    end
+
+    if taskbar == nil do
+      OS.shutdown()
+      {:noreply, ui}
+    else
+      :wxFrame.hide(frame)
+      {:noreply, ui}
+    end
+  end
+end
+```
+
+### 4. `@moduledoc` (`lib/desktop/window.ex`)
+
+Document the new option alongside the existing configuration options:
+
+```
+* `:on_close` - controls the behavior when the native window close
+  button is clicked.
+
+    Possible values are:
+
+    * `:quit` - Shut down the application (default). This is the
+      legacy behavior and is appropriate for main/primary windows.
+
+    * `:hide` - Hide the window instead of quitting. Useful for
+      secondary windows (e.g. settings, preferences) that should
+      be dismissible without terminating the application.
+```
+
+### 5. `desktop.install` mix task (`lib/mix/tasks/desktop.install.ex`)
+
+Guard the module definition with `Code.ensure_loaded?/1` so the optional
+`igniter` dependency doesn't cause compilation failures when Desktop is used as
+a path dependency:
+
+```elixir
+if Code.ensure_loaded?(Igniter.Mix.Task) do
+  defmodule Mix.Tasks.Desktop.Install do
+    # ...
+  end
+end
+```
+
+---
+
+## Backwards Compatibility
+
+- The default value of `on_close` is `:quit`, which preserves the exact
+  existing behavior for all current users.
+- No existing configuration options are modified or removed.
+- The `taskbar`-based logic is unchanged when `on_close` is `:quit`.
+- Applications that do not pass `on_close` will behave identically to
+  previous versions.
+
+---
+
+## Testing
+
+Manual verification:
+
+1. **Primary window with `on_close: :quit` (default):** Clicking the close
+   button shuts down the application — unchanged behavior.
+2. **Secondary window with `on_close: :hide`:** Clicking the close button
+   hides the window. The application continues running. The window can be
+   re-shown via `Desktop.Window.show/2`.
+3. **macOS Cmd+Q:** Application quits normally regardless of `on_close`
+   setting on any window.

--- a/lib/desktop/window.ex
+++ b/lib/desktop/window.ex
@@ -73,6 +73,18 @@ defmodule Desktop.Window do
     * `:url` - a callback to the initial (default) url to show in the
       window.
 
+    * `:on_close` - controls the behavior when the native window close
+      button is clicked.
+
+        Possible values are:
+
+        * `:quit` - Shut down the application (default). This is the
+          legacy behavior and is appropriate for main/primary windows.
+
+        * `:hide` - Hide the window instead of quitting. Useful for
+          secondary windows (e.g. settings, preferences) that should
+          be dismissible without terminating the application.
+
   """
 
   alias Desktop.{OS, Window, Wx, Menu, Fallback}
@@ -87,7 +99,8 @@ defmodule Desktop.Window do
     :webview,
     :home_url,
     :last_url,
-    :title
+    :title,
+    on_close: :quit
   ]
 
   @doc false
@@ -121,6 +134,7 @@ defmodule Desktop.Window do
     icon_menu = unless OS.mobile?(), do: options[:icon_menu]
     hidden = unless OS.mobile?(), do: options[:hidden]
     url = options[:url]
+    on_close = options[:on_close] || :quit
 
     Desktop.Env.wx_use_env()
     GenServer.cast(Desktop.Env, {:register_window, self()})
@@ -209,7 +223,8 @@ defmodule Desktop.Window do
       notifications: %{},
       home_url: url,
       title: window_title,
-      taskbar: taskbar
+      taskbar: taskbar,
+      on_close: on_close
     }
 
     if hidden != true do
@@ -565,26 +580,31 @@ defmodule Desktop.Window do
   end
 
   @doc false
-  def handle_cast(:close_window, ui = %Window{frame: frame, taskbar: taskbar}) do
-    # On macOS, there's no way to differentiate between following two events:
-    #
-    # * the window close event
-    # * the application close event
-    #
-    # So, this code assumes that if there's a closet_window event coming in while
-    # the window in not actually shown, then it must be an application close event.
-    #
-    # On other platforms, this code should not have any relevance.
-    if not :wxFrame.isShown(frame) do
-      OS.shutdown()
-    end
-
-    if taskbar == nil do
-      OS.shutdown()
-      {:noreply, ui}
-    else
+  def handle_cast(:close_window, ui = %Window{frame: frame, taskbar: taskbar, on_close: on_close}) do
+    if on_close == :hide do
       :wxFrame.hide(frame)
       {:noreply, ui}
+    else
+      # On macOS, there's no way to differentiate between following two events:
+      #
+      # * the window close event
+      # * the application close event
+      #
+      # So, this code assumes that if there's a close_window event coming in while
+      # the window is not actually shown, then it must be an application close event.
+      #
+      # On other platforms, this code should not have any relevance.
+      if not :wxFrame.isShown(frame) do
+        OS.shutdown()
+      end
+
+      if taskbar == nil do
+        OS.shutdown()
+        {:noreply, ui}
+      else
+        :wxFrame.hide(frame)
+        {:noreply, ui}
+      end
     end
   end
 

--- a/lib/mix/tasks/desktop.install.ex
+++ b/lib/mix/tasks/desktop.install.ex
@@ -1,182 +1,182 @@
 if Code.ensure_loaded?(Igniter.Mix.Task) do
-defmodule Mix.Tasks.Desktop.Install do
-  @shortdoc "Add Elixir Desktop support to an existing project"
+  defmodule Mix.Tasks.Desktop.Install do
+    @shortdoc "Add Elixir Desktop support to an existing project"
 
-  @moduledoc """
-  #{@shortdoc}
+    @moduledoc """
+    #{@shortdoc}
 
-  This mix task adds the minimal glue to launch an Elixir Desktop
-  main window for your application.
+    This mix task adds the minimal glue to launch an Elixir Desktop
+    main window for your application.
 
-  To use this task, you'll either need to install Igniter globally, or
-  manually add the desktop dependency to your project's mix.exs:
+    To use this task, you'll either need to install Igniter globally, or
+    manually add the desktop dependency to your project's mix.exs:
 
-  ```
-  {:desktop, "~> 1.0"}
-  ```
+    ```
+    {:desktop, "~> 1.0"}
+    ```
 
-  ## Examples
+    ## Examples
 
-  Add desktop support to a project:
+    Add desktop support to a project:
 
-  ```bash
-  mix desktop.install
-  ```
+    ```bash
+    mix desktop.install
+    ```
 
-  Create a new project with desktop support:
+    Create a new project with desktop support:
 
-  ```bash
-  mix archive.install hex igniter_new
+    ```bash
+    mix archive.install hex igniter_new
 
-  mix igniter.new my_app --install desktop --with phx.new
-  ```
-  """
+    mix igniter.new my_app --install desktop --with phx.new
+    ```
+    """
 
-  use Igniter.Mix.Task
+    use Igniter.Mix.Task
 
-  @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
-    %Igniter.Mix.Task.Info{
-      # Groups allow for overlapping arguments for tasks by the same author
-      # See the generators guide for more.
-      group: :desktop
-    }
-  end
+    @impl Igniter.Mix.Task
+    def info(_argv, _composing_task) do
+      %Igniter.Mix.Task.Info{
+        # Groups allow for overlapping arguments for tasks by the same author
+        # See the generators guide for more.
+        group: :desktop
+      }
+    end
 
-  @impl Igniter.Mix.Task
-  def igniter(igniter) do
-    app = Igniter.Project.Application.app_name(igniter)
-    endpoint = Igniter.Libs.Phoenix.web_module_name(igniter, "Endpoint")
-    menu = Igniter.Project.Module.module_name(igniter, "Menu")
-    menubar = Igniter.Project.Module.module_name(igniter, "MenuBar")
-    gettext = Igniter.Libs.Phoenix.web_module_name(igniter, "Gettext")
-    main_window = Igniter.Project.Module.module_name(igniter, MainWindow)
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      app = Igniter.Project.Application.app_name(igniter)
+      endpoint = Igniter.Libs.Phoenix.web_module_name(igniter, "Endpoint")
+      menu = Igniter.Project.Module.module_name(igniter, "Menu")
+      menubar = Igniter.Project.Module.module_name(igniter, "MenuBar")
+      gettext = Igniter.Libs.Phoenix.web_module_name(igniter, "Gettext")
+      main_window = Igniter.Project.Module.module_name(igniter, MainWindow)
 
-    igniter
-    |> Igniter.compose_task("igniter.add", ["desktop"])
-    |> add_menu_bar(menubar, gettext, endpoint)
-    |> add_menu(menu, gettext, app, main_window)
-    |> Igniter.Project.Application.add_new_child(
-      {
-        Desktop.Window,
-        {:code,
-         quote do
-           [
-             app: unquote(app),
-             id: unquote(Igniter.Project.Module.module_name(igniter, MainWindow)),
-             title: unquote(to_string(app)),
-             size: {600, 500},
-             # icon: "icon.png", # TODO: ship an example taskbar icon here
-             menubar: unquote(menubar),
-             icon_menu: unquote(menu),
-             url: &unquote(endpoint).url/0
-           ]
-         end}
-      },
-      after: [endpoint]
-    )
+      igniter
+      |> Igniter.compose_task("igniter.add", ["desktop"])
+      |> add_menu_bar(menubar, gettext, endpoint)
+      |> add_menu(menu, gettext, app, main_window)
+      |> Igniter.Project.Application.add_new_child(
+        {
+          Desktop.Window,
+          {:code,
+           quote do
+             [
+               app: unquote(app),
+               id: unquote(Igniter.Project.Module.module_name(igniter, MainWindow)),
+               title: unquote(to_string(app)),
+               size: {600, 500},
+               # icon: "icon.png", # TODO: ship an example taskbar icon here
+               menubar: unquote(menubar),
+               icon_menu: unquote(menu),
+               url: &unquote(endpoint).url/0
+             ]
+           end}
+        },
+        after: [endpoint]
+      )
 
-    # TODO: Add runtime_tools observer if available, or optionall add the dependency
-  end
+      # TODO: Add runtime_tools observer if available, or optionall add the dependency
+    end
 
-  defp add_menu_bar(igniter, menubar, gettext, endpoint) do
-    Igniter.Project.Module.find_and_update_or_create_module(
-      igniter,
-      menubar,
-      """
-        @moduledoc \"""
-          Menu bar that is shown as part of the main window on Windows/Linux. In
-          MacOS this menu bar appears at the very top of the screen.
-        \"""
-        use Gettext, backend: #{inspect(gettext)}
-        use Desktop.Menu
-        alias Desktop.Window
-
-        @impl true
-        def render(assigns) do
-          ~H\"""
-          <menubar>
-          <menu label={gettext "File"}>
-              <item onclick="quit">{gettext "Quit"}</item>
-          </menu>
-          <menu label={gettext "Extra"}>
-              <item onclick="browser">{gettext "Open Browser"}</item>
-          </menu>
-          </menubar>
+    defp add_menu_bar(igniter, menubar, gettext, endpoint) do
+      Igniter.Project.Module.find_and_update_or_create_module(
+        igniter,
+        menubar,
+        """
+          @moduledoc \"""
+            Menu bar that is shown as part of the main window on Windows/Linux. In
+            MacOS this menu bar appears at the very top of the screen.
           \"""
-        end
+          use Gettext, backend: #{inspect(gettext)}
+          use Desktop.Menu
+          alias Desktop.Window
 
-        @impl true
-        def handle_event("quit", menu) do
-          Window.quit()
-          {:noreply, menu}
-        end
-
-        def handle_event("browser", menu) do
-          Window.prepare_url(#{inspect(endpoint)}.url())
-          |> :wx_misc.launchDefaultBrowser()
-
-          {:noreply, menu}
-        end
-
-        @impl true
-        def handle_info(_, menu) do
-          {:noreply, menu}
-        end
-
-        @impl true
-        def mount(menu) do
-          {:ok, menu}
-        end
-      """,
-      fn zipper -> {:ok, zipper} end
-    )
-  end
-
-  defp add_menu(igniter, menu, gettext, app, main_window) do
-    Igniter.Project.Module.find_and_update_or_create_module(
-      igniter,
-      menu,
-      """
-        @moduledoc \"""
-        Menu that is shown when a user clicks on the taskbar icon of the #{app}
-        \"""
-        use Gettext, backend: #{inspect(gettext)}
-        use Desktop.Menu
-
-        @impl true
-        def render(assigns) do
-          ~H\"""
-          <menu>
-            <item onclick="edit">{gettext "Open"}</item>
-            <hr/>
-            <item onclick="quit">{gettext "Quit"}</item>
-          </menu>
-          \"""
-        end
-
-        @impl true
-        def handle_event(command, menu) do
-          case command do
-            <<"quit">> -> Desktop.Window.quit()
-            <<"edit">> -> Desktop.Window.show(#{inspect(main_window)})
+          @impl true
+          def render(assigns) do
+            ~H\"""
+            <menubar>
+            <menu label={gettext "File"}>
+                <item onclick="quit">{gettext "Quit"}</item>
+            </menu>
+            <menu label={gettext "Extra"}>
+                <item onclick="browser">{gettext "Open Browser"}</item>
+            </menu>
+            </menubar>
+            \"""
           end
 
-          {:noreply, menu}
-        end
+          @impl true
+          def handle_event("quit", menu) do
+            Window.quit()
+            {:noreply, menu}
+          end
 
-        @impl true
-        def handle_info(_, menu) do
-          {:noreply, menu}
-        end
+          def handle_event("browser", menu) do
+            Window.prepare_url(#{inspect(endpoint)}.url())
+            |> :wx_misc.launchDefaultBrowser()
 
-        @impl true
-        def mount(menu) do
-          {:ok, menu}
-        end
-      """,
-      fn zipper -> {:ok, zipper} end
-    )
+            {:noreply, menu}
+          end
+
+          @impl true
+          def handle_info(_, menu) do
+            {:noreply, menu}
+          end
+
+          @impl true
+          def mount(menu) do
+            {:ok, menu}
+          end
+        """,
+        fn zipper -> {:ok, zipper} end
+      )
+    end
+
+    defp add_menu(igniter, menu, gettext, app, main_window) do
+      Igniter.Project.Module.find_and_update_or_create_module(
+        igniter,
+        menu,
+        """
+          @moduledoc \"""
+          Menu that is shown when a user clicks on the taskbar icon of the #{app}
+          \"""
+          use Gettext, backend: #{inspect(gettext)}
+          use Desktop.Menu
+
+          @impl true
+          def render(assigns) do
+            ~H\"""
+            <menu>
+              <item onclick="edit">{gettext "Open"}</item>
+              <hr/>
+              <item onclick="quit">{gettext "Quit"}</item>
+            </menu>
+            \"""
+          end
+
+          @impl true
+          def handle_event(command, menu) do
+            case command do
+              <<"quit">> -> Desktop.Window.quit()
+              <<"edit">> -> Desktop.Window.show(#{inspect(main_window)})
+            end
+
+            {:noreply, menu}
+          end
+
+          @impl true
+          def handle_info(_, menu) do
+            {:noreply, menu}
+          end
+
+          @impl true
+          def mount(menu) do
+            {:ok, menu}
+          end
+        """,
+        fn zipper -> {:ok, zipper} end
+      )
+    end
   end
-end
 end

--- a/lib/mix/tasks/desktop.install.ex
+++ b/lib/mix/tasks/desktop.install.ex
@@ -1,3 +1,4 @@
+if Code.ensure_loaded?(Igniter.Mix.Task) do
 defmodule Mix.Tasks.Desktop.Install do
   @shortdoc "Add Elixir Desktop support to an existing project"
 
@@ -177,4 +178,5 @@ defmodule Mix.Tasks.Desktop.Install do
       fn zipper -> {:ok, zipper} end
     )
   end
+end
 end


### PR DESCRIPTION

## Problem

Applications that use multiple `Desktop.Window` instances have no way to control
what happens when a user clicks the native close button (the red X on macOS, the
X on Windows/Linux) on a secondary window.

The current `handle_cast(:close_window, ...)` implementation decides the close
behavior based on the presence of a `taskbar` (which is derived from the
`icon_menu` option):

```elixir
if taskbar == nil do
  OS.shutdown()    # terminates the entire application
else
  :wxFrame.hide(frame)
end
```

This means the **only** way to get hide-on-close behavior is to provide an
`icon_menu`, which creates a system tray icon. For secondary windows like
Settings or Preferences panels, this is inappropriate — they should be
dismissible without either terminating the application or requiring a taskbar
icon.

### Impact

On macOS, `OS.shutdown()` during wxWidgets teardown of a secondary window causes
a segmentation fault (SIGSEGV, exit code 139). On other platforms it causes an
unexpected full application exit when the user only intended to close a secondary
window.

---

## Solution

Add an explicit `on_close` configuration option to `Desktop.Window` that
decouples the close behavior from the taskbar presence.

### New Option

| Option | Values | Default | Description |
|---|---|---|---|
| `:on_close` | `:quit`, `:hide` | `:quit` | Controls behavior when the native close button is clicked |

- **`:quit`** — Existing behavior. Shuts down the application (via
  `OS.shutdown()`). Appropriate for primary/main windows.
- **`:hide`** — Hides the window frame. Appropriate for secondary windows
  (settings, preferences, tool panels) that should be dismissible without
  terminating the application.

### Usage

```elixir
children = [
  # Primary window — closes the app (default behavior, unchanged)
  {Desktop.Window,
   [
     app: :my_app,
     id: MainWindow,
     title: "My App",
     icon_menu: MyApp.IconMenu,
     url: &MyAppWeb.Endpoint.url/0
   ]},

  # Secondary window — hides on close
  {Desktop.Window,
   [
     app: :my_app,
     id: SettingsWindow,
     title: "Settings",
     hidden: true,
     on_close: :hide,
     url: fn -> MyAppWeb.Endpoint.url() <> "/settings" end
   ]}
]
```

---

## Changes

### 1. `%Desktop.Window{}` struct (`lib/desktop/window.ex`)

Add `on_close` field with a default of `:quit` for full backwards compatibility:

```elixir
defstruct [
  :module,
  :taskbar,
  :frame,
  :notifications,
  :webview,
  :home_url,
  :last_url,
  :title,
  on_close: :quit
]
```

### 2. `init/1` (`lib/desktop/window.ex`)

Read the option from the configuration keywords and store it in the struct:

```elixir
on_close = options[:on_close] || :quit

ui = %Window{
  frame: frame,
  webview: Fallback.webview_new(frame),
  notifications: %{},
  home_url: url,
  title: window_title,
  taskbar: taskbar,
  on_close: on_close
}
```

### 3. `handle_cast(:close_window, ...)` (`lib/desktop/window.ex`)

Check `on_close` before falling through to the existing logic:

```elixir
def handle_cast(:close_window, ui = %Window{frame: frame, taskbar: taskbar, on_close: on_close}) do
  if on_close == :hide do
    :wxFrame.hide(frame)
    {:noreply, ui}
  else
    # Existing behavior preserved exactly as-is
    if not :wxFrame.isShown(frame) do
      OS.shutdown()
    end

    if taskbar == nil do
      OS.shutdown()
      {:noreply, ui}
    else
      :wxFrame.hide(frame)
      {:noreply, ui}
    end
  end
end
```

### 4. `@moduledoc` (`lib/desktop/window.ex`)

Document the new option alongside the existing configuration options:

```
* `:on_close` - controls the behavior when the native window close
  button is clicked.

    Possible values are:

    * `:quit` - Shut down the application (default). This is the
      legacy behavior and is appropriate for main/primary windows.

    * `:hide` - Hide the window instead of quitting. Useful for
      secondary windows (e.g. settings, preferences) that should
      be dismissible without terminating the application.
```

### 5. `desktop.install` mix task (`lib/mix/tasks/desktop.install.ex`)

Guard the module definition with `Code.ensure_loaded?/1` so the optional
`igniter` dependency doesn't cause compilation failures when Desktop is used as
a path dependency:

```elixir
if Code.ensure_loaded?(Igniter.Mix.Task) do
  defmodule Mix.Tasks.Desktop.Install do
    # ...
  end
end
```

---

## Backwards Compatibility

- The default value of `on_close` is `:quit`, which preserves the exact
  existing behavior for all current users.
- No existing configuration options are modified or removed.
- The `taskbar`-based logic is unchanged when `on_close` is `:quit`.
- Applications that do not pass `on_close` will behave identically to
  previous versions.

---

## Testing

Manual verification:

1. **Primary window with `on_close: :quit` (default):** Clicking the close
   button shuts down the application — unchanged behavior.
2. **Secondary window with `on_close: :hide`:** Clicking the close button
   hides the window. The application continues running. The window can be
   re-shown via `Desktop.Window.show/2`.
3. **macOS Cmd+Q:** Application quits normally regardless of `on_close`
   setting on any window.
