### PR TITLE
Add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is an **Elixir library** (not a standalone app). It provides native desktop windowing for Phoenix LiveView apps via wxWidgets.
+
+### Toolchain
+
+Erlang and Elixir versions are managed via `.tool-versions` (asdf format). The Cloud VM uses **mise** to resolve these. After the update script runs, `erl` and `elixir` are available on `PATH`.
+
+### System dependencies
+
+wxWidgets GUI support requires `libwxgtk-webview3.2-dev` and `xvfb` on headless Linux. These are pre-installed in the VM snapshot.
+
+### Key commands
+
+| Task | Command |
+|---|---|
+| Install deps | `mix deps.get` |
+| Compile | `mix compile` |
+| Lint (all) | `mix lint` (runs compile --warnings-as-errors, format --check-formatted, credo --ignore refactor, dialyzer) |
+| Tests | `xvfb-run mix test` |
+| Run code | `xvfb-run mix run -e '<elixir code>'` |
+| IEx shell | `xvfb-run iex -S mix` |
+
+### Known issues
+
+- **Dialyzer warnings**: `mix dialyzer` emits pre-existing warnings in `lib/mix/tasks/desktop.install.ex` related to the optional `igniter` dependency. These also fail in CI on `main`.
+- **Install test**: `test/mix/tasks/desktop.install_test.exs` fails because `Igniter.Test.phx_test_project/1` requires a working `mix phx.new` integration that does not fully resolve in all environments. This is pre-existing and CI does not run `mix test`.
+- **GLib warning**: `xvfb-run` may emit a harmless `GLib-WARNING` about `g_spawn_sync()` / `ECHILD`; this is cosmetic and can be ignored.
+
+### Running without a display
+
+All commands that load the `:wx` application (compile, test, iex) need a display. Use `xvfb-run` prefix on headless servers. The `NO_WX` environment variable can skip wx initialization but will limit functionality.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

### What's included

- Toolchain info (mise-managed Erlang/Elixir from `.tool-versions`)
- System dependency notes (wxWidgets, xvfb for headless)
- Quick reference table of key dev commands (`mix lint`, `xvfb-run mix test`, etc.)
- Known pre-existing issues (dialyzer warnings, igniter install test failure)
- Headless display guidance (`xvfb-run` prefix requirement)

### Why

Future Cursor Cloud agents benefit from knowing non-obvious setup caveats like the `xvfb-run` requirement, pre-existing CI failures, and the fact that this is a library (not a standalone app).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d42b3454-c01a-4638-8a72-0587363c5dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d42b3454-c01a-4638-8a72-0587363c5dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

