### PR TITLE
Simplify os_description trim; rebase on main

### DIFF
--- a/lib/desktop/platform/system.ex
+++ b/lib/desktop/platform/system.ex
@@ -49,15 +49,11 @@ defmodule Desktop.Platform.System do
         end
       end)
 
-    case raw do
-      nil ->
-        nil
-
-      str ->
-        case String.trim(str) do
-          "" -> nil
-          trimmed -> trimmed
-        end
+    if raw do
+      case String.trim(raw) do
+        "" -> nil
+        trimmed -> trimmed
+      end
     end
   end
 

--- a/test/desktop/platform_system_test.exs
+++ b/test/desktop/platform_system_test.exs
@@ -16,7 +16,6 @@ defmodule Desktop.Platform.SystemTest do
 
     on_exit(fn ->
       Application.put_env(:desktop, :backend, previous)
-      Process.delete(:stub_os_description)
     end)
 
     :ok


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rebased onto `main` (PR #74 already merged)
- Simplified nested `case` in `Desktop.Platform.System.os_description/0` to `if raw do … end` (Gemini feedback)
- Removed no-op `Process.delete/1` from `on_exit` in `platform_system_test.exs` (cleanup runs in a separate process)

## Test plan
- [x] `mix test test/desktop/platform_system_test.exs test/desktop/backend/json_test.exs test/desktop/backend/browser_test.exs test/desktop/regression/beam_wx_calls_test.exs --exclude wx`
- [x] `mix test.guard`
- [x] `xvfb-run -a mix test test/desktop/backend/wx_test.exs --only wx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c0b6ce8-cd34-4bef-b7e2-cbefd57356ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c0b6ce8-cd34-4bef-b7e2-cbefd57356ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

