### PR TITLE
Accept charlist URLs in open_external_url / HostBrowser.open

### DIFF
--- a/lib/desktop/impl/host_browser.ex
+++ b/lib/desktop/impl/host_browser.ex
@@ -4,7 +4,9 @@ defmodule Desktop.Impl.HostBrowser do
 
   alias Desktop.OS
 
-  @spec open(String.t()) :: :ok
+  @spec open(String.t() | charlist()) :: :ok
+  def open(url) when is_list(url), do: open(List.to_string(url))
+
   def open(url) when is_binary(url) do
     spawn(fn -> run_open(url) end)
     :ok

--- a/lib/desktop/platform/system.ex
+++ b/lib/desktop/platform/system.ex
@@ -32,7 +32,13 @@ defmodule Desktop.Platform.System do
   end
 
   def wx_available?, do: impl().wx_available?()
-  def open_external_url(url), do: Helpers.with_wx_env(fn -> impl().open_external_url(url) end)
+
+  # wxWebView and other OTP APIs pass URLs as charlists; backends expect binaries.
+  def open_external_url(url) when is_list(url), do: open_external_url(List.to_string(url))
+
+  def open_external_url(url) when is_binary(url) do
+    Helpers.with_wx_env(fn -> impl().open_external_url(url) end)
+  end
 
   @doc """
   Returns a human-readable OS / device description string.

--- a/test/desktop/backend/browser_test.exs
+++ b/test/desktop/backend/browser_test.exs
@@ -42,6 +42,12 @@ defmodule Desktop.Backend.BrowserTest do
     refute Browser.wx_available?()
   end
 
+  test "T-BRW: open_external_url accepts binary and charlist" do
+    assert :ok = Browser.open_external_url("https://example.com")
+    assert :ok = Browser.open_external_url(~c"https://example.com")
+    assert :ok = Desktop.Impl.HostBrowser.open(~c"https://example.com")
+  end
+
   test "T-BRW: content reload is no-op" do
     assert :ok = Browser.reload(nil)
   end

--- a/test/desktop/regression/beam_wx_calls_test.exs
+++ b/test/desktop/regression/beam_wx_calls_test.exs
@@ -52,6 +52,12 @@ defmodule Desktop.Regression.BeamWxCallsTest do
     assert :ok = PlatformSystem.open_external_url("https://example.com")
   end
 
+  test "open_external_url accepts wx-style charlist URLs" do
+    assert :ok = PlatformSystem.open_external_url(~c"https://example.com")
+    assert is_pid(Desktop.OS.launch_default_browser(~c"https://example.com"))
+    Process.sleep(50)
+  end
+
   test "activate_event_active? on Json backend returns true without wx" do
     assert Json.activate_event_active?(%{})
     assert PlatformSystem.activate_event_active?(%{})


### PR DESCRIPTION
wxWebView new-window events pass charlist URLs; the Platform rewrite only accepted binaries and raised FunctionClauseError when opening links.