### PR TITLE
Allow configurable menu adapters for third-party backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ All commands that load the `:wx` application (compile, test, iex) need a display
 | `Desktop.Backend.Json` | `:mobile_target` compile config or `OS.mobile?/0` — JSON bridge via `BRIDGE_PORT` |
 | `Desktop.Backend.Browser` | `NO_WX=1` or `:wx` unavailable |
 
-Override with `config :desktop, :backend, :wx | :json | :browser | :auto`.
+Override with `config :desktop, :backend, :wx | :json | :browser | :auto` or a custom module.
+Custom backends may set `config :desktop, :menu_adapter, Some.Menu.Adapter` (used by `desktop_webview`).
 
 ### Platform abstraction (do not regress)
 

--- a/guides/faq.md
+++ b/guides/faq.md
@@ -34,6 +34,14 @@ For a custom implementation, set the backend to a module that implements the `De
 config :desktop, :backend, MyApp.DesktopBackend
 ```
 
+Third-party backends that ship their own menu adapter (for example [`desktop_webview`](https://github.com/elixir-desktop/webview)) should also set:
+
+```elixir
+config :desktop, :menu_adapter, DesktopWebview.Menu.Adapter
+```
+
+`Desktop.Platform.Menu.adapter/1` prefers `config :desktop, :menu_adapter` when present, then falls back to Wx / Json / DBus / Browser selection.
+
 Restart the app after changing backend config — the router reads `Application.get_env(:desktop, :backend, :auto)` at runtime.
 
 ### Environment variables

--- a/lib/desktop/menu.ex
+++ b/lib/desktop/menu.ex
@@ -291,13 +291,10 @@ defmodule Desktop.Menu do
 
     adapter_module =
       case Keyword.get(init_opts, :adapter) do
-        mod when mod in [Adapter.Wx, Adapter.DBus, Adapter.Json, Adapter.Browser] ->
+        mod when is_atom(mod) and not is_nil(mod) ->
           mod
 
         nil ->
-          Desktop.Platform.Menu.adapter(init_opts)
-
-        _ ->
           Desktop.Platform.Menu.adapter(init_opts)
       end
 

--- a/lib/desktop/platform/menu.ex
+++ b/lib/desktop/platform/menu.ex
@@ -11,7 +11,10 @@ defmodule Desktop.Platform.Menu do
     caps = Desktop.Platform.capabilities()
 
     cond do
-      Keyword.get(opts, :adapter) in [Adapter.Wx, Adapter.DBus, Adapter.Json, Adapter.Browser] ->
+      mod = Application.get_env(:desktop, :menu_adapter) ->
+        mod
+
+      Keyword.get(opts, :adapter) ->
         Keyword.get(opts, :adapter)
 
       Keyword.get(opts, :sni) != nil and Desktop.Platform.backend() == Desktop.Backend.Wx ->


### PR DESCRIPTION
## Summary
- Honor `config :desktop, :menu_adapter` in `Desktop.Platform.Menu.adapter/1` so packages like [`desktop_webview`](https://github.com/elixir-desktop/webview) can supply their own menu adapter.
- Accept any adapter module via `Desktop.Menu` start opts (not only Wx/Json/DBus/Browser).
- Document the option in FAQ and AGENTS.md.

## Test plan
- [ ] `mix test.fast` / existing menu tests still pass
- [ ] With `config :desktop, :menu_adapter, Some.Adapter`, `Desktop.Platform.Menu.adapter([])` returns that module
- [ ] Without the config, existing Wx/Json/DBus/Browser selection is unchanged


Made with [Cursor](https://cursor.com)