### PR TITLE
Make :wx an optional host extra_application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,19 @@ defmodule Desktop.MixProject do
   end
 
   def extra_applications(:host) do
-    [:wx]
+    # Only include `:wx` when the OTP it would be loaded on actually has the
+    # `:wx` OTP application available. Without this guard, `mix release`
+    # aborts with "Could not find application :wx" when the build host's
+    # Erlang/OTP was configured `--without-wx` (e.g. on the macOS installer
+    # CI now that the workflow drops the custom wxWidgets build). The Erlang
+    # source file `src/desktop_wx.erl` already adapts to missing wx headers
+    # via `desktop_wx_stub.exs`, so a host build without `:wx` simply
+    # compiles the stub backend.
+    if :code.lib_dir(:wx) |> is_list() do
+      [:wx]
+    else
+      []
+    end
   end
 
   def extra_applications(_mobile) do


### PR DESCRIPTION
## Problem

On hosts whose Erlang/OTP was configured `--without-wx`, `mix release` (and the higher-level `mix desktop.installer`) aborts with:

```
** (Mix) Could not find application :wx
```

We hit this in `elixir-desktop/diode-drive`'s macOS installer workflow when we dropped the custom wxWidgets build and switched the WebView backend to `elixir-desktop/desktop_webview`. The OTP installed on the builder no longer provides the `:wx` OTP application, but `desktop`'s `extra_applications(:host)` still declares `[:wx]`, so every release validation step fails before `desktop_wx_stub.exs` has any chance to regenerate `src/desktop_wx.erl`.

## Fix

Only declare `:wx` in `extra_applications(:host)` when `:code.lib_dir(:wx)` actually returns a chardir. That is the same OTP presence probe `desktop_wx_stub.exs` already uses to decide whether to emit the header-free stub Erlang source vs. the `wx.hrl`-including real source. A host build on OTP built `--without-wx` now compiles the stub backend; a host build on OTP that ships `:wx` keeps the existing behavior.

## Diff

```diff
   def extra_applications(:host) do
-    [:wx]
+    if :code.lib_dir(:wx) |> is_list() do
+      [:wx]
+    else
+      []
+    end
   end
```

## Verification

- `mix compile --warnings-as-errors` clean on OTP that ships `:wx`.
- `:code.lib_dir(:wx) |> is_list()` returns `true` on standard OTP and `false` on OTP built `--without-wx` (returns `{:error, :bad_name}`, which is not a list).

## Why not also remove `:wx` from `mix.exs` entirely

`Desktop.Window.{Macos,Windows,Linux}` and `Desktop.Webview.wx` still real-call into `:wx` / `wxWidgets` when available, and the project still recommends `mix desktop.installer` workflows on Linux and Windows where wx is expected to be present. We only want to stop *requiring* it on platforms where the installer drops wx support.

## Out of scope

The macOS-side change that motivated this PR (the WebView switch + dropping the wxWidgets build in `binaries_macos.yml`) lives in `elixir-desktop/diode-drive`, not here.